### PR TITLE
Update Type 14 damage to 12, based on testing

### DIFF
--- a/build/ace_compat/config.cpp
+++ b/build/ace_compat/config.cpp
@@ -64,7 +64,7 @@ class CfgAmmo
 	};
 	class Type14_LasBolt: BulletBase
 	{
-		hit = 11.6;
+		hit = 12;
 		caliber = 3;
 	};
 	class Lucius22c_Pellets: ShotgunBase


### PR DESCRIPTION
This will give the Type 14 an advantage compared to the Lucius on damage. This should drop (knock unconscious) regular enemies in 3 hits very consistantly.